### PR TITLE
Directly use A_target and remove Units.mol_air

### DIFF
--- a/nuVeto/nuveto.py
+++ b/nuVeto/nuveto.py
@@ -338,7 +338,7 @@ class nuVeto(object):
                   / Units.cm)
 
         # number of targets per cm2
-        ndens = rho_air*Units.Na/Units.mol_air
+        ndens = rho_air*Units.Na/config.A_target
         sec = self.mceq.pman[p_pdg]
         prim2mceq = {'p+-bar': 'pbar-',
                      'n0-bar': 'nbar0',

--- a/nuVeto/utils.py
+++ b/nuVeto/utils.py
@@ -2,7 +2,6 @@ import os
 import pickle
 from importlib import resources
 from MCEq.geometry.geometry import EarthGeometry
-from MCEq import config
 import numpy as np
 from scipy.interpolate import RegularGridInterpolator
 from particletools.tables import SibyllParticleTable, PYTHIAParticleData
@@ -22,7 +21,6 @@ class Units(object):
     MeV = 1e-3*GeV
     TeV = 1.e3*GeV
     PeV = 1.e3*TeV
-    mol_air = config.A_target
     phim2 = (m**2*GeV*sec)**-1
     phicm2 = (cm**2*GeV*sec)**-1
 


### PR DESCRIPTION
Simplifies the imports and also ensures Units are static