### PR TITLE
Potential fix for code scanning alert no. 6: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -19,6 +19,9 @@ on:
     # * is a special character in YAML so you have to quote this string
     - cron:  '25 9 * * 2'
 
+permissions:
+  contents: read
+
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true


### PR DESCRIPTION
Potential fix for [https://github.com/tianluyuan/nuVeto/security/code-scanning/6](https://github.com/tianluyuan/nuVeto/security/code-scanning/6)

Add an explicit `permissions` block at the workflow root so it applies to all jobs unless overridden. For this workflow, `contents: read` is the best minimal permission and does not change functionality, since the jobs mainly checkout code, install dependencies, lint, and run tests.

**Best single fix:** in `.github/workflows/build_and_test.yml`, insert:

```yml
permissions:
  contents: read
```

right after the trigger section (`on:` block) and before `concurrency:`.  
No imports, methods, or additional definitions are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
