### PR TITLE
Address new default ruleset in ruff 0.16

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -38,16 +38,15 @@ jobs:
       uses: actions/setup-python@v6
       with:
         python-version: ${{ matrix.python-version }}
+    - uses: astral-sh/ruff-action@v3
+      with:
+        src: "src scripts"
+        version: "latest"        
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
         if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
-        pip install flake8
         pip install -e .[testing]
-    - name: Lint with flake8
-      run: |
-        # stop the build if there are Python syntax errors or undefined names
-        flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics
     - name: Run pytest
       run: pytest
     - name: Test mu.py

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -41,7 +41,7 @@ jobs:
     - uses: astral-sh/ruff-action@v3
       with:
         src: "src scripts"
-        version: "latest"        
+        version: "latest"
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -43,3 +43,8 @@ where = ["src/"]
 
 [tool.ruff]
 exclude = ["external"]
+
+[tool.ruff.lint]
+ignore = [
+    "N999", # Allow invalid (non-lowercase) module names
+]

--- a/src/nuVeto/__init__.py
+++ b/src/nuVeto/__init__.py
@@ -1,11 +1,13 @@
 from . import mu, nuveto, uncertainties, utils
 from .nuveto import builder, fluxes, nuVeto, passing
 
-__all__ = ['mu',
-           'utils',
-           'nuveto',
-           'uncertainties',
-           'nuVeto',
-           'passing',
+__all__ = [
+           'builder',
            'fluxes',
-           'builder']
+           'mu',
+           'nuVeto',
+           'nuveto',
+           'passing',
+           'uncertainties',
+           'utils',
+]

--- a/src/nuVeto/examples/plots.py
+++ b/src/nuVeto/examples/plots.py
@@ -447,7 +447,7 @@ def hist_preach(infile, plotdir=None):
     import pandas as pd
     napf = 36
     df = pd.read_csv(infile, sep=r'\s+', header=None,
-                     names='ei l ef'.split())
+                     names=['ei', 'l', 'ef'])
     # If the muon doesn't reach, MMC saves ef as -distance traveled
     df[df < 0] = 0
     for idx, (ei, sdf) in enumerate(df.groupby('ei')):

--- a/src/nuVeto/examples/plots.py
+++ b/src/nuVeto/examples/plots.py
@@ -457,7 +457,7 @@ def hist_preach(infile, plotdir=None):
                 plt.tight_layout()
                 if plotdir is not None:
                     plt.savefig(Path(plotdir).expanduser() /  f'{(idx - 1) / napf}.png')
-            fig, axs = plt.subplots(6, 6, figsize=(10, 10))
+            _fig, axs = plt.subplots(6, 6, figsize=(10, 10))
             # fig.text(0.5, 0.04, r'$E_f$', ha='center', va='center')
             # fig.text(0.06, 0.5, r'$P(E_f|E_i, l)$', ha='center', va='center', rotation='vertical')
             axs = axs.flatten()

--- a/src/nuVeto/mu.py
+++ b/src/nuVeto/mu.py
@@ -19,7 +19,7 @@ def hist_preach(infile):
     """
     Hist = namedtuple('Hist', 'counts edges')
     df = pd.read_csv(infile, sep=r'\s+', header=None,
-                     names='ei l ef'.split())
+                     names=['ei', 'l', 'ef'])
     # If the muon doesn't reach, MMC saves ef as -distance traveled
     df[df < 0] = 0
     preach = []
@@ -51,7 +51,7 @@ def int_ef(preach, plight):
         with (resources.files('nuVeto') / 'data' / 'mmc' / f'{preach.with_suffix(".npz")}').open('rb') as f:
             preach = np.load(f)['data']
 
-    df = pd.DataFrame(preach, columns='ei l ef ew pdf'.split())
+    df = pd.DataFrame(preach, columns=['ei', 'l', 'ef', 'ew', 'pdf'])
     intg = []
     for (ei, _l), sdf in df.groupby(['ei', 'l']):
         intg.append((ei, _l, np.sum(sdf['ew']*sdf['pdf']*plight(sdf['ef']))))
@@ -63,7 +63,7 @@ def interp(preach, plight):
     """ returns an interpolate.RegularGridInterpolator of integral preach * plight over e_f, yields prpl
     """
     intg = int_ef(preach, plight)
-    df = pd.DataFrame(intg, columns='ei l prpl'.split())
+    df = pd.DataFrame(intg, columns=['ei', 'l', 'prpl'])
     df = df.pivot_table(index='ei', columns='l', values='prpl').fillna(0)
     return interpolate.RegularGridInterpolator((df.index, df.columns), df.values, bounds_error=False, fill_value=None)
 

--- a/src/nuVeto/mu.py
+++ b/src/nuVeto/mu.py
@@ -43,7 +43,8 @@ def int_ef(preach, plight):
         if preach.suffix == '.npz':
             preach = np.load(preach)['data']
         elif preach.suffix == '.pklz':
-            preach = pickle.load(gzip.open(preach, 'rb'))
+            with gzip.open(preach, 'rb') as gz:
+                preach = pickle.load(gz)
         else:
             preach = hist_preach(preach)
     else:
@@ -95,7 +96,7 @@ class MuonProb:
     @staticmethod
     def load_from_npz(f):
         data = np.load(f)
-        ngrid_keys = len([_ for _ in data.keys() if _.startswith('grid_')])
+        ngrid_keys = len([_ for _ in data if _.startswith('grid_')])
         grid = tuple(data[f'grid_{_}'] for _ in range(ngrid_keys))
 
         return RegularGridInterpolator(

--- a/src/nuVeto/nuveto.py
+++ b/src/nuVeto/nuveto.py
@@ -14,10 +14,9 @@ from typing import NamedTuple
 
 import crflux.models as pm
 import numpy as np
-import scipy.integrate as integrate
-import scipy.interpolate as interpolate
 from MCEq import config, misc
 from MCEq.core import MCEqRun
+from scipy import integrate, interpolate
 
 from .mu import MuonProb
 from .utils import Geometry, ParticleProperties, Units, amu, centers
@@ -32,7 +31,7 @@ class MCEqArgs(NamedTuple):
     density: tuple
 
 
-class nuVeto(object):
+class nuVeto:
     """Class for computing the neutrino passing fraction i.e. (1-(Veto probability))
     Initializes the nuVeto object for a specific physical configuration.
 

--- a/src/nuVeto/nuveto.py
+++ b/src/nuVeto/nuveto.py
@@ -89,6 +89,11 @@ class nuVeto:
         self._X_vec = X_vec[:-1] * 0.57 + X_vec[1:] * 0.43
         self._rho = nuVeto.mceq.density_model.X2rho(self.X_vec) * Units.gr / Units.cm**3
 
+        # Note: lru_cache is applied here to the bound methods below to avoid B019 error
+        self.grid_sol = lru_cache(maxsize=2**12)(self._grid_sol)
+        self.nmu = lru_cache(maxsize=2**12)(self._nmu)
+        self.get_rescale_phi = lru_cache(maxsize=2**12)(self._get_rescale_phi)
+
     def __repr__(self):
         return (
             f"<{self.__class__.__name__}(\n"
@@ -322,8 +327,7 @@ class nuVeto:
 
         return x_range, dNdEE, dNdEE_interp
 
-    @lru_cache(maxsize=2**12)
-    def grid_sol(self, ecr=None, particle=None):
+    def _grid_sol(self, ecr=None, particle=None):
         """MCEq grid solution for \\frac{dN_{CR,p}}_{dE_p}"""
         self.sync_mceq()
         if ecr is not None:
@@ -333,8 +337,7 @@ class nuVeto:
         nuVeto.mceq.solve(int_grid=self.X_vec, grid_var="X")
         return nuVeto.mceq.grid_sol
 
-    @lru_cache(maxsize=2**12)
-    def nmu(self, ecr, particle, prpl="ice_allm97_step_1"):
+    def _nmu(self, ecr, particle, prpl="ice_allm97_step_1"):
         """Number of expected muons for a given primary energy / particle.
         Used to compute the Poisson probability of getting no muons"""
         grid_sol = self.grid_sol(ecr, particle)
@@ -351,8 +354,7 @@ class nuVeto:
             mu * fn.prpl(coords) * nuVeto.mceq.e_grid, np.log(nuVeto.mceq.e_grid)
         )
 
-    @lru_cache(maxsize=2**12)
-    def get_rescale_phi(self, mother, ecr=None, particle=None):
+    def _get_rescale_phi(self, mother, ecr=None, particle=None):
         """Flux of the mother at all heights"""
         grid_sol = self.grid_sol(
             ecr, particle

--- a/src/nuVeto/tests/test_app.py
+++ b/src/nuVeto/tests/test_app.py
@@ -130,7 +130,7 @@ def test_pnmshower(cth):
 @pytest.mark.parametrize('enu,l_ice,mother',
                          product(np.logspace(3, 7, 5),
                                  np.linspace(1500, 100000, 5),
-                                 'mu+ pi+ K+ K_L0 D+ D0 D_s+'.split()))
+                                 ['mu+', 'pi+', 'K+', 'K_L0', 'D+', 'D0', 'D_s+']))
 def test_pnmsib(enu, l_ice, mother):
     psibs = nuVeto.psib(l_ice, mother, enu, 3, 'ice_allm97_step_1')
     assert np.all(0 <= psibs) and np.all(psibs <= 1)

--- a/src/nuVeto/utils.py
+++ b/src/nuVeto/utils.py
@@ -64,7 +64,7 @@ class Geometry(EarthGeometry):
     def __init__(self, depth):
         """ Depth of detector and elevation of surface above sea-level
         """
-        super(Geometry, self).__init__()
+        super().__init__()
         self.depth = depth
         self.h_obs *= Units.cm
         self.h_atm *= Units.cm

--- a/src/nuVeto/utils.py
+++ b/src/nuVeto/utils.py
@@ -1,3 +1,5 @@
+from typing import ClassVar
+
 import numpy as np
 from MCEq.geometry.geometry import EarthGeometry
 from particletools.tables import PYTHIAParticleData, SibyllParticleTable
@@ -25,10 +27,10 @@ class ParticleProperties:
     modtab = SibyllParticleTable()
     pd = PYTHIAParticleData()
 
-    mass_dict = {}
-    lifetime_dict = {}
-    pdg_id = {}
-    sibling = {}
+    mass_dict: ClassVar[dict] = {}
+    lifetime_dict: ClassVar[dict] = {}
+    pdg_id: ClassVar[dict] = {}
+    sibling: ClassVar[dict] = {}
 
     for k in modtab.part_table:
         pdg_id[k] = modtab.modname2pdg[k]


### PR DESCRIPTION
Fixes (or ignores). Addresses potential memory leak from lru_cache on self.
```
N999 Invalid module name: 'nuVeto'
--> src/nuVeto/__init__.py:1:1

RUF022 [*] `__all__` is not sorted
  --> src/nuVeto/__init__.py:4:11
   |
 2 |   from .nuveto import builder, fluxes, nuVeto, passing
 3 |
 4 |   __all__ = ['mu',
   |  ___________^
 5 | |            'utils',
 6 | |            'nuveto',
 7 | |            'uncertainties',
 8 | |            'nuVeto',
 9 | |            'passing',
10 | |            'fluxes',
11 | |            'builder']
   | |_____________________^
   |
help: Apply an isort-style sorting to `__all__`
   |
3  |
   - __all__ = ['mu',
   -            'utils',
4  + __all__ = [
5  +            'builder',
6  +            'fluxes',
7  +            'mu',
8  +            'nuVeto',
9  |            'nuveto',
   -            'uncertainties',
   -            'nuVeto',
10 |            'passing',
   -            'fluxes',
   -            'builder']
11 +            'uncertainties',
12 +            'utils',
13 + ]
   |

N999 Invalid module name: 'nuVeto'
--> src/nuVeto/examples/__init__.py:1:1

SIM905 [*] Consider using a list literal instead of `str.split`
   --> src/nuVeto/examples/plots.py:450:28
    |
448 |     napf = 36
449 |     df = pd.read_csv(infile, sep=r'\s+', header=None,
450 |                      names='ei l ef'.split())
    |                            ^^^^^^^^^^^^^^^^^
451 |     # If the muon doesn't reach, MMC saves ef as -distance traveled
452 |     df[df < 0] = 0
    |
help: Replace with list literal
    |
449 |     df = pd.read_csv(infile, sep=r'\s+', header=None,
    -                      names='ei l ef'.split())
450 +                      names=['ei', 'l', 'ef'])
451 |     # If the muon doesn't reach, MMC saves ef as -distance traveled
    |

RUF059 Unpacked variable `fig` is never used
   --> src/nuVeto/examples/plots.py:460:13
    |
458 |                 if plotdir is not None:
459 |                     plt.savefig(Path(plotdir).expanduser() /  f'{(idx - 1) / napf}.png')
460 |             fig, axs = plt.subplots(6, 6, figsize=(10, 10))
    |             ^^^
461 |             # fig.text(0.5, 0.04, r'$E_f$', ha='center', va='center')
462 |             # fig.text(0.06, 0.5, r'$P(E_f|E_i, l)$', ha='center', va='center', rotation='vertical')
    |
help: Prefix it with an underscore or any other dummy variable pattern

SIM905 [*] Consider using a list literal instead of `str.split`
  --> src/nuVeto/mu.py:22:28
   |
20 |     Hist = namedtuple('Hist', 'counts edges')
21 |     df = pd.read_csv(infile, sep=r'\s+', header=None,
22 |                      names='ei l ef'.split())
   |                            ^^^^^^^^^^^^^^^^^
23 |     # If the muon doesn't reach, MMC saves ef as -distance traveled
24 |     df[df < 0] = 0
   |
help: Replace with list literal
   |
21 |     df = pd.read_csv(infile, sep=r'\s+', header=None,
   -                      names='ei l ef'.split())
22 +                      names=['ei', 'l', 'ef'])
23 |     # If the muon doesn't reach, MMC saves ef as -distance traveled
   |

SIM115 Use a context manager for opening files
  --> src/nuVeto/mu.py:46:34
   |
44 |             preach = np.load(preach)['data']
45 |         elif preach.suffix == '.pklz':
46 |             preach = pickle.load(gzip.open(preach, 'rb'))
   |                                  ^^^^^^^^^
47 |         else:
48 |             preach = hist_preach(preach)
   |

SIM905 [*] Consider using a list literal instead of `str.split`
  --> src/nuVeto/mu.py:54:39
   |
52 |             preach = np.load(f)['data']
53 |
54 |     df = pd.DataFrame(preach, columns='ei l ef ew pdf'.split())
   |                                       ^^^^^^^^^^^^^^^^^^^^^^^^
55 |     intg = []
56 |     for (ei, _l), sdf in df.groupby(['ei', 'l']):
   |
help: Replace with list literal
   |
53 |
   -     df = pd.DataFrame(preach, columns='ei l ef ew pdf'.split())
54 +     df = pd.DataFrame(preach, columns=['ei', 'l', 'ef', 'ew', 'pdf'])
55 |     intg = []
   |

SIM905 [*] Consider using a list literal instead of `str.split`
  --> src/nuVeto/mu.py:66:37
   |
64 |     """
65 |     intg = int_ef(preach, plight)
66 |     df = pd.DataFrame(intg, columns='ei l prpl'.split())
   |                                     ^^^^^^^^^^^^^^^^^^^
67 |     df = df.pivot_table(index='ei', columns='l', values='prpl').fillna(0)
68 |     return interpolate.RegularGridInterpolator((df.index, df.columns), df.values, bounds_error=False, fill_value=None)
   |
help: Replace with list literal
   |
65 |     intg = int_ef(preach, plight)
   -     df = pd.DataFrame(intg, columns='ei l prpl'.split())
66 +     df = pd.DataFrame(intg, columns=['ei', 'l', 'prpl'])
67 |     df = df.pivot_table(index='ei', columns='l', values='prpl').fillna(0)
   |

SIM118 Use `key in dict` instead of `key in dict.keys()`
  --> src/nuVeto/mu.py:98:33
   |
96 |     def load_from_npz(f):
97 |         data = np.load(f)
98 |         ngrid_keys = len([_ for _ in data.keys() if _.startswith('grid_')])
   |                                 ^^^^^^^^^^^^^^^^
99 |         grid = tuple(data[f'grid_{_}'] for _ in range(ngrid_keys))
   |
help: Remove `.keys()`

PLR0402 [*] Use `from scipy import integrate` in lieu of alias
  --> src/nuVeto/nuveto.py:17:8
   |
15 | import crflux.models as pm
16 | import numpy as np
17 | import scipy.integrate as integrate
   |        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
18 | import scipy.interpolate as interpolate
19 | from MCEq import config, misc
   |
help: Replace with `from scipy import integrate`
   |
16 | import numpy as np
   - import scipy.integrate as integrate
17 + from scipy import integrate
18 | import scipy.interpolate as interpolate
   |

PLR0402 [*] Use `from scipy import interpolate` in lieu of alias
  --> src/nuVeto/nuveto.py:18:8
   |
16 | import numpy as np
17 | import scipy.integrate as integrate
18 | import scipy.interpolate as interpolate
   |        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
19 | from MCEq import config, misc
20 | from MCEq.core import MCEqRun
   |
help: Replace with `from scipy import interpolate`
   |
17 | import scipy.integrate as integrate
   - import scipy.interpolate as interpolate
18 + from scipy import interpolate
19 | from MCEq import config, misc
   |

UP004 [*] Class `nuVeto` inherits from `object`
  --> src/nuVeto/nuveto.py:35:14
   |
35 | class nuVeto(object):
   |              ^^^^^^
36 |     """Class for computing the neutrino passing fraction i.e. (1-(Veto probability))
37 |     Initializes the nuVeto object for a specific physical configuration.
   |
help: Remove `object` inheritance
   |
34 |
   - class nuVeto(object):
35 + class nuVeto:
36 |     """Class for computing the neutrino passing fraction i.e. (1-(Veto probability))
   |

B019 Use of `functools.lru_cache` or `functools.cache` on methods can lead to memory leaks
   --> src/nuVeto/nuveto.py:326:5
    |
324 |         return x_range, dNdEE, dNdEE_interp
325 |
326 |     @lru_cache(maxsize=2**12)
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^
327 |     def grid_sol(self, ecr=None, particle=None):
328 |         """MCEq grid solution for \\frac{dN_{CR,p}}_{dE_p}"""
    |

B019 Use of `functools.lru_cache` or `functools.cache` on methods can lead to memory leaks
   --> src/nuVeto/nuveto.py:337:5
    |
335 |         return nuVeto.mceq.grid_sol
336 |
337 |     @lru_cache(maxsize=2**12)
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^
338 |     def nmu(self, ecr, particle, prpl="ice_allm97_step_1"):
339 |         """Number of expected muons for a given primary energy / particle.
    |

B019 Use of `functools.lru_cache` or `functools.cache` on methods can lead to memory leaks
   --> src/nuVeto/nuveto.py:355:5
    |
353 |         )
354 |
355 |     @lru_cache(maxsize=2**12)
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^
356 |     def get_rescale_phi(self, mother, ecr=None, particle=None):
357 |         """Flux of the mother at all heights"""
    |

SIM905 [*] Consider using a list literal instead of `str.split`
   --> src/nuVeto/tests/test_app.py:133:34
    |
131 |                          product(np.logspace(3, 7, 5),
132 |                                  np.linspace(1500, 100000, 5),
133 |                                  'mu+ pi+ K+ K_L0 D+ D0 D_s+'.split()))
    |                                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
134 | def test_pnmsib(enu, l_ice, mother):
135 |     psibs = nuVeto.psib(l_ice, mother, enu, 3, 'ice_allm97_step_1')
    |
help: Replace with list literal
    |
132 |                                  np.linspace(1500, 100000, 5),
    -                                  'mu+ pi+ K+ K_L0 D+ D0 D_s+'.split()))
133 +                                  ['mu+', 'pi+', 'K+', 'K_L0', 'D+', 'D0', 'D_s+']))
134 | def test_pnmsib(enu, l_ice, mother):
    |

RUF012 Mutable default value for class attribute
  --> src/nuVeto/utils.py:28:17
   |
26 |     pd = PYTHIAParticleData()
27 |
28 |     mass_dict = {}
   |                 ^^
29 |     lifetime_dict = {}
30 |     pdg_id = {}
   |
help: Consider initializing in `__init__` or annotating with `typing.ClassVar`

RUF012 Mutable default value for class attribute
  --> src/nuVeto/utils.py:29:21
   |
28 |     mass_dict = {}
29 |     lifetime_dict = {}
   |                     ^^
30 |     pdg_id = {}
31 |     sibling = {}
   |
help: Consider initializing in `__init__` or annotating with `typing.ClassVar`

RUF012 Mutable default value for class attribute
  --> src/nuVeto/utils.py:30:14
   |
28 |     mass_dict = {}
29 |     lifetime_dict = {}
30 |     pdg_id = {}
   |              ^^
31 |     sibling = {}
   |
help: Consider initializing in `__init__` or annotating with `typing.ClassVar`

RUF012 Mutable default value for class attribute
  --> src/nuVeto/utils.py:31:15
   |
29 |     lifetime_dict = {}
30 |     pdg_id = {}
31 |     sibling = {}
   |               ^^
32 |
33 |     for k in modtab.part_table:
   |
help: Consider initializing in `__init__` or annotating with `typing.ClassVar`

UP008 [*] Use `super()` instead of `super(__class__, self)`
  --> src/nuVeto/utils.py:67:14
   |
65 |         """ Depth of detector and elevation of surface above sea-level
66 |         """
67 |         super(Geometry, self).__init__()
   |              ^^^^^^^^^^^^^^^^
68 |         self.depth = depth
69 |         self.h_obs *= Units.cm
   |
help: Remove `super()` parameters
   |
66 |         """
   -         super(Geometry, self).__init__()
67 +         super().__init__()
68 |         self.depth = depth
   |

Found 22 errors.
[*] 10 fixable with the `--fix` option (2 hidden fixes can be enabled with the `--unsafe-fixes` option).
```